### PR TITLE
fix: アクセスカウンターの hydration mismatch を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ sw.*
 
 # Claude Code
 .claude/settings.local.json
+.playwright-mcp/
 
 # yarn
 .yarn/*

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -21,7 +21,9 @@ const accessCount = `0000000000000000${Math.floor(
       <tbt-blink>🎉🎉🎉🎉🎉🎉🎉M3-2024秋参戦決定！🎉🎉🎉🎉🎉🎉</tbt-blink>
     </p>
     <tbt-marquee> ＼奇跡の2年連続参戦！／ M3-2024秋に参戦！ </tbt-marquee>
-    <tbt-access-counter-section :access-count="accessCount" />
+    <ClientOnly>
+      <tbt-access-counter-section :access-count="accessCount" />
+    </ClientOnly>
     <tbt-news-section />
     <tbt-circle-cut-section />
     <tbt-circle-space-info-section />

--- a/test/unit/specs/pages/Index.spec.ts
+++ b/test/unit/specs/pages/Index.spec.ts
@@ -10,6 +10,7 @@ describe('index.vue', () => {
     global: {
       stubs: {
         NuxtLink: RouterLinkStub,
+        ClientOnly: { template: '<slot />' },
       },
     },
   })


### PR DESCRIPTION
## Summary

- `<ClientOnly>` でアクセスカウンターを囲み、クライアントサイドのみでレンダリングするよう変更
- `Math.random()` が SSR とクライアントで別々に実行されることで発生していた Vue の hydration mismatch を解消

## Background

アクセスカウンターはランダムな飾り数値を表示するもので、SSR で HTML に埋め込む必要がない。
GitHub Pages (SSG) へのデプロイを前提とすると `<ClientOnly>` がもっとも適切な解決策。

## Test plan

- [ ] `http://localhost:3000/` を開いてアクセスカウンターが表示されること
- [ ] ブラウザコンソールに hydration mismatch エラーが出ないこと
- [ ] SSR レスポンス HTML にアクセスカウンターのテキストが含まれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)