### PR TITLE
fix: メニューの🍺マーカーを list-style-type に変更

### DIFF
--- a/app/components/organisms/TbtMenu.vue
+++ b/app/components/organisms/TbtMenu.vue
@@ -44,7 +44,7 @@ import TbtBeenyaLink from '@/components/atoms/TbtBeenyaLink.vue'
 }
 
 .menu {
-  list-style-type: "🍺";
+  list-style-type: '🍺';
   padding-left: 1.25em;
 }
 

--- a/app/components/organisms/TbtMenu.vue
+++ b/app/components/organisms/TbtMenu.vue
@@ -44,15 +44,17 @@ import TbtBeenyaLink from '@/components/atoms/TbtBeenyaLink.vue'
 }
 
 .menu {
-  list-style: none;
+  list-style-type: "🍺";
+  padding-left: 1.25em;
+}
+
+.menu ::marker {
+  font-size: 1.25em;
 }
 
 .menu-item {
   margin-bottom: 20px;
-}
-
-.menu-item::before {
-  content: '🍺';
+  padding-left: 0.25em;
 }
 
 .visually-hidden {


### PR DESCRIPTION
Closes #1537

## Summary

- `.menu-item::before { content: '🍺' }` を廃止し、`list-style-type: "🍺"` に変更
- Issue コメントのレイアウト調整も適用（`padding-left`、`::marker` の `font-size`）

## Changes

```css
/* Before */
.menu { list-style: none; }
.menu-item::before { content: '🍺'; }

/* After */
.menu { list-style-type: "🍺"; padding-left: 1.25em; }
.menu ::marker { font-size: 1.25em; }
.menu-item { padding-left: 0.25em; }
```

## Test plan

- [ ] ナビメニューに🍺が表示されること
- [ ] 全テスト通過（ローカル確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)