### PR TITLE
fix: add Vitest globals to ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,42 +2,55 @@ import globals from 'globals'
 import withNuxt from './.nuxt/eslint.config.mjs'
 import eslintConfigPrettier from 'eslint-config-prettier'
 
-export default withNuxt(eslintConfigPrettier, {
-  files: ['**/*.js', '**/*.vue', '**/*.ts'],
-  languageOptions: {
-    globals: {
-      ...globals.browser,
-      ...globals.node,
+export default withNuxt(
+  eslintConfigPrettier,
+  {
+    files: ['**/*.js', '**/*.vue', '**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    rules: {
+      // Vue 3 Composition API推奨
+      'vue/component-api-style': ['error', ['script-setup']],
+      'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
+
+      // コード品質
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'no-debugger': 'error',
+      'prefer-const': 'error',
+      'no-var': 'error',
+
+      // TypeScript推奨
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+
+      // Vue固有
+      'vue/multi-word-component-names': 'off', // Nuxt Pagesは単語1つでOK
+      'vue/require-default-prop': 'off', // TypeScriptで型推論があるため
+      'vue/html-self-closing': [
+        'error',
+        {
+          html: { void: 'always', normal: 'never', component: 'always' },
+        },
+      ],
     },
   },
-  rules: {
-    // Vue 3 Composition API推奨
-    'vue/component-api-style': ['error', ['script-setup']],
-    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
-    'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
-
-    // コード品質
-    'no-console': ['warn', { allow: ['warn', 'error'] }],
-    'no-debugger': 'error',
-    'prefer-const': 'error',
-    'no-var': 'error',
-
-    // TypeScript推奨
-    '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      'warn',
-      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-    ],
-
-    // Vue固有
-    'vue/multi-word-component-names': 'off', // Nuxt Pagesは単語1つでOK
-    'vue/require-default-prop': 'off', // TypeScriptで型推論があるため
-    'vue/html-self-closing': [
-      'error',
-      {
-        html: { void: 'always', normal: 'never', component: 'always' },
+  {
+    files: ['test/**/*.{spec,test}.{ts,js}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.vitest,
       },
-    ],
+    },
   },
-})
+)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,24 +34,6 @@ export default defineNuxtConfig({
         { name: 'twitter:image', content: OGP_IMAGE },
         // PWA
         { name: 'theme-color', content: '#ffffff' },
-        // CSP（静的サイトのためHTTPヘッダーではなくmetaタグで設定）
-        {
-          'http-equiv': 'Content-Security-Policy',
-          content: [
-            "default-src 'self'",
-            // Nuxt SSGのハイドレーションペイロードにインラインスクリプトが含まれるため unsafe-inline が必要
-            "script-src 'self' 'unsafe-inline'",
-            "style-src 'self' 'unsafe-inline'",
-            "img-src 'self' data:",
-            'frame-src https://www.youtube.com',
-            "connect-src 'self'",
-            "font-src 'self'",
-            "worker-src 'self'",
-            "object-src 'none'",
-            "base-uri 'self'",
-            "form-action 'self'",
-          ].join('; '),
-        },
       ],
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,24 @@ export default defineNuxtConfig({
         { name: 'twitter:image', content: OGP_IMAGE },
         // PWA
         { name: 'theme-color', content: '#ffffff' },
+        // CSP（静的サイトのためHTTPヘッダーではなくmetaタグで設定）
+        {
+          'http-equiv': 'Content-Security-Policy',
+          content: [
+            "default-src 'self'",
+            // Nuxt SSGのハイドレーションペイロードにインラインスクリプトが含まれるため unsafe-inline が必要
+            "script-src 'self' 'unsafe-inline'",
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data:",
+            'frame-src https://www.youtube.com',
+            "connect-src 'self'",
+            "font-src 'self'",
+            "worker-src 'self'",
+            "object-src 'none'",
+            "base-uri 'self'",
+            "form-action 'self'",
+          ].join('; '),
+        },
       ],
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },

--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "env": { 
-    "jest": true
-  },
-  "globals": { 
-  }
-}


### PR DESCRIPTION
## Summary

`test/unit/.eslintrc` が ESLint 9+ フラットコンフィグで完全無視されていたため、テスト設定を正しく修正。

### 変更内容
- `test/unit/.eslintrc`（`jest: true` のまま放置）を削除
- `eslint.config.mjs` にテストファイル向けの `globals.vitest` を追加

```js
{
  files: ['test/**/*.{spec,test}.{ts,js}'],
  languageOptions: {
    globals: { ...globals.vitest },
  },
}
```

これにより `describe`・`it`・`expect`・`vi` 等が ESLint に正式認識される。

## Test plan

- [x] `yarn lint` パス
- [x] `yarn test --run` 全テスト通過（22/22）
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)