### PR TITLE
fix: add json to PWA workbox globPatterns

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -79,7 +79,7 @@ export default defineNuxtConfig({
     },
     workbox: {
       navigateFallback: '/',
-      globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
+      globPatterns: ['**/*.{js,css,html,json,png,svg,ico}'],
     },
     client: {
       installPrompt: true,


### PR DESCRIPTION
## Summary

`nuxt generate` のビルド成果物には `_nuxt/builds/latest.json` 等の JSON ファイルが含まれるが、Workbox の `globPatterns` に `json` が含まれていなかった。

PWA としてインストールされた環境でオフライン時にこれらのファイルが取得できず、ナビゲーションが不完全になる可能性があった。

```diff
- globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
+ globPatterns: ['**/*.{js,css,html,json,png,svg,ico}'],
```

## Test plan

- [x] `yarn lint` パス
- [x] `yarn test --run` 全テスト通過（22/22）
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)